### PR TITLE
Weekly Merge 10

### DIFF
--- a/src/modules/data/wrap_ByteData.cpp
+++ b/src/modules/data/wrap_ByteData.cpp
@@ -76,27 +76,6 @@ int w_ByteData_setT(lua_State *L)
 	return 0;
 }
 
-template <typename T>
-int w_ByteData_getT(lua_State *L)
-{
-	ByteData *t = luax_checkbytedata(L, 1);
-	int64 offset = (int64) luaL_checknumber(L, 2);
-	int count = (int) luaL_optinteger(L, 3, 1);
-
-	if (count <= 0)
-		return luaL_error(L, "Invalid count parameter (must be greater than 0)");
-
-	if (offset < 0 || offset + sizeof(T) * count > t->getSize())
-		return luaL_error(L, "The given offset and count parameters don't fit within the ByteData's size.");
-
-	auto data = (const T *)((uint8 *) t->getData() + offset);
-
-	for (int i = 0; i < count; i++)
-		lua_pushnumber(L, (lua_Number) data[i]);
-
-	return count;
-}
-
 int w_ByteData_setFloat(lua_State *L)
 {
 	return w_ByteData_setT<float>(L);
@@ -147,56 +126,6 @@ int w_ByteData_setUInt64(lua_State *L)
 	return w_ByteData_setT<uint64>(L);
 }
 
-int w_ByteData_getFloat(lua_State *L)
-{
-	return w_ByteData_getT<float>(L);
-}
-
-int w_ByteData_getDouble(lua_State *L)
-{
-	return w_ByteData_getT<double>(L);
-}
-
-int w_ByteData_getInt8(lua_State *L)
-{
-	return w_ByteData_getT<int8>(L);
-}
-
-int w_ByteData_getUInt8(lua_State *L)
-{
-	return w_ByteData_getT<uint8>(L);
-}
-
-int w_ByteData_getInt16(lua_State *L)
-{
-	return w_ByteData_getT<int16>(L);
-}
-
-int w_ByteData_getUInt16(lua_State *L)
-{
-	return w_ByteData_getT<uint16>(L);
-}
-
-int w_ByteData_getInt32(lua_State *L)
-{
-	return w_ByteData_getT<int32>(L);
-}
-
-int w_ByteData_getUInt32(lua_State *L)
-{
-	return w_ByteData_getT<uint32>(L);
-}
-
-int w_ByteData_getInt64(lua_State *L)
-{
-	return w_ByteData_getT<int64>(L);
-}
-
-int w_ByteData_getUInt64(lua_State *L)
-{
-	return w_ByteData_getT<uint64>(L);
-}
-
 static const luaL_Reg w_ByteData_functions[] =
 {
 	{ "clone", w_ByteData_clone },
@@ -210,16 +139,6 @@ static const luaL_Reg w_ByteData_functions[] =
 	{ "setUInt32", w_ByteData_setUInt32 },
 	{ "setInt64", w_ByteData_setInt64 },
 	{ "setUInt64", w_ByteData_setUInt64 },
-	{ "getFloat", w_ByteData_getFloat },
-	{ "getDouble", w_ByteData_getDouble },
-	{ "getInt8", w_ByteData_getInt8 },
-	{ "getUInt8", w_ByteData_getUInt8 },
-	{ "getInt16", w_ByteData_getInt16 },
-	{ "getUInt16", w_ByteData_getUInt16 },
-	{ "getInt32", w_ByteData_getInt32 },
-	{ "getUInt32", w_ByteData_getUInt32 },
-	{ "getInt64", w_ByteData_getInt64 },
-	{ "getUInt64", w_ByteData_getUInt64 },
 	{ 0, 0 }
 };
 

--- a/src/modules/data/wrap_ByteData.cpp
+++ b/src/modules/data/wrap_ByteData.cpp
@@ -44,8 +44,27 @@ int w_ByteData_clone(lua_State *L)
 	return 1;
 }
 
+int w_ByteData_setString(lua_State *L)
+{
+	Data *t = luax_checkdata(L, 1);
+	size_t size = 0;
+	const char *str = luaL_checklstring(L, 2, &size);
+	int64 offset = (int64)luaL_optnumber(L, 3, 0);
+
+	size = std::min(size, t->getSize());
+
+	if (size == 0)
+		return 0;
+
+	if (offset < 0 || offset + size > (int64) t->getSize())
+		return luaL_error(L, "The given string offset and size don't fit within the Data's size.");
+
+	memcpy((char *) t->getData() + (size_t) offset, str, size);
+	return 0;
+}
+
 template <typename T>
-int w_ByteData_setT(lua_State *L)
+static int w_ByteData_setT(lua_State *L)
 {
 	ByteData *t = luax_checkbytedata(L, 1);
 	int64 offset = (int64) luaL_checknumber(L, 2);
@@ -129,6 +148,7 @@ int w_ByteData_setUInt64(lua_State *L)
 static const luaL_Reg w_ByteData_functions[] =
 {
 	{ "clone", w_ByteData_clone },
+	{ "setString", w_ByteData_setString },
 	{ "setFloat", w_ByteData_setFloat },
 	{ "setDouble", w_ByteData_setDouble },
 	{ "setInt8", w_ByteData_setInt8 },

--- a/src/modules/data/wrap_ByteData.cpp
+++ b/src/modules/data/wrap_ByteData.cpp
@@ -73,7 +73,7 @@ static int w_ByteData_setT(lua_State *L)
 	int nargs = std::max(1, istable ? (int) luax_objlen(L, 3) : lua_gettop(L) - 2);
 
 	if (offset < 0 || offset + sizeof(T) * nargs > t->getSize())
-		return luaL_error(L, "");
+		return luaL_error(L, "The given offset and value parameters don't fit within the Data's size.");
 
 	auto data = (T *)((uint8 *) t->getData() + offset);
 

--- a/src/modules/data/wrap_Data.cpp
+++ b/src/modules/data/wrap_Data.cpp
@@ -78,6 +78,77 @@ int w_Data_getSize(lua_State *L)
 	return 1;
 }
 
+template <typename T>
+static int w_Data_getT(lua_State* L)
+{
+	Data* t = luax_checkdata(L, 1);
+	int64 offset = (int64)luaL_checknumber(L, 2);
+	int count = (int)luaL_optinteger(L, 3, 1);
+
+	if (count <= 0)
+		return luaL_error(L, "Invalid count parameter (must be greater than 0)");
+
+	if (offset < 0 || offset + sizeof(T) * count > t->getSize())
+		return luaL_error(L, "The given offset and count parameters don't fit within the Data's size.");
+
+	auto data = (const T*)((uint8*)t->getData() + offset);
+
+	for (int i = 0; i < count; i++)
+		lua_pushnumber(L, (lua_Number)data[i]);
+
+	return count;
+}
+
+int w_Data_getFloat(lua_State* L)
+{
+	return w_Data_getT<float>(L);
+}
+
+int w_Data_getDouble(lua_State* L)
+{
+	return w_Data_getT<double>(L);
+}
+
+int w_Data_getInt8(lua_State* L)
+{
+	return w_Data_getT<int8>(L);
+}
+
+int w_Data_getUInt8(lua_State* L)
+{
+	return w_Data_getT<uint8>(L);
+}
+
+int w_Data_getInt16(lua_State* L)
+{
+	return w_Data_getT<int16>(L);
+}
+
+int w_Data_getUInt16(lua_State* L)
+{
+	return w_Data_getT<uint16>(L);
+}
+
+int w_Data_getInt32(lua_State* L)
+{
+	return w_Data_getT<int32>(L);
+}
+
+int w_Data_getUInt32(lua_State* L)
+{
+	return w_Data_getT<uint32>(L);
+}
+
+int w_Data_getInt64(lua_State* L)
+{
+	return w_Data_getT<int64>(L);
+}
+
+int w_Data_getUInt64(lua_State* L)
+{
+	return w_Data_getT<uint64>(L);
+}
+
 // C functions in a struct, necessary for the FFI versions of Data methods.
 struct FFI_Data
 {
@@ -99,6 +170,16 @@ const luaL_Reg w_Data_functions[] =
 	{ "getPointer", w_Data_getPointer },
 	{ "getFFIPointer", w_Data_getFFIPointer },
 	{ "getSize", w_Data_getSize },
+	{ "getFloat", w_Data_getFloat },
+	{ "getDouble", w_Data_getDouble },
+	{ "getInt8", w_Data_getInt8 },
+	{ "getUInt8", w_Data_getUInt8 },
+	{ "getInt16", w_Data_getInt16 },
+	{ "getUInt16", w_Data_getUInt16 },
+	{ "getInt32", w_Data_getInt32 },
+	{ "getUInt32", w_Data_getUInt32 },
+	{ "getInt64", w_Data_getInt64 },
+	{ "getUInt64", w_Data_getUInt64 },
 	{ 0, 0 }
 };
 

--- a/src/modules/data/wrap_DataModule.cpp
+++ b/src/modules/data/wrap_DataModule.cpp
@@ -326,6 +326,28 @@ int w_hash(lua_State *L)
 
 int w_pack(lua_State *L)
 {
+	if (luax_istype(L, 1, ByteData::type))
+	{
+		ByteData *d = luax_checkbytedata(L, 1);
+		size_t offset = (size_t) luaL_checknumber(L, 2);
+		const char *fmt = luaL_checkstring(L, 3);
+
+		luaL_Buffer_53 b;
+		lua53_str_pack(L, fmt, 4, &b);
+
+		if (offset + b.nelems > d->getSize())
+		{
+			lua53_cleanupbuffer(&b);
+			return luaL_error(L, "The given byte offset and pack format parameters do not fit within the ByteData's size.");
+		}
+
+		memcpy((uint8 *) d->getData() + offset, b.ptr, b.nelems);
+
+		lua53_cleanupbuffer(&b);
+		luax_pushtype(L, Data::type, d);
+		return 1;
+	}
+
 	ContainerType ctype = luax_checkcontainertype(L, 1);
 	const char *fmt = luaL_checkstring(L, 2);
 	luaL_Buffer_53 b;

--- a/src/modules/graphics/Buffer.h
+++ b/src/modules/graphics/Buffer.h
@@ -132,6 +132,11 @@ public:
 	virtual bool fill(size_t offset, size_t size, const void *data) = 0;
 
 	/**
+	 * Reset the given portion of this buffer's data to 0.
+	 */
+	virtual void clear(size_t offset, size_t size) = 0;
+
+	/**
 	 * Copy a portion of this Buffer's data to another buffer, using the GPU.
 	 **/
 	virtual void copyTo(Buffer *dest, size_t sourceoffset, size_t destoffset, size_t size) = 0;

--- a/src/modules/graphics/Graphics.cpp
+++ b/src/modules/graphics/Graphics.cpp
@@ -1370,6 +1370,9 @@ void Graphics::copyBuffer(Buffer *source, Buffer *dest, size_t sourceoffset, siz
 	if (dest->isImmutable())
 		throw love::Exception("Cannot copy to an immutable buffer.");
 
+	if (sourceoffset % 4 != 0 || destoffset % 4 != 0 || size % 4 != 0)
+		throw love::Exception("Buffer copy source offset, destination offset, and size parameters must be multiples of 4 bytes.");
+
 	source->copyTo(dest, sourceoffset, destoffset, size);
 }
 
@@ -1456,6 +1459,9 @@ void Graphics::copyTextureToBuffer(Texture *source, Buffer *dest, int slice, int
 
 	Range destrange(destoffset, size);
 
+	if (destoffset % 4 != 0 || size % 4 != 0)
+		throw love::Exception("Buffer copy destination offset and computed byte size must be multiples of 4 bytes.");
+
 	if (destrange.getMax() >= dest->getSize())
 		throw love::Exception("Buffer copy destination offset and width/height doesn't fit within the destination Buffer.");
 
@@ -1535,6 +1541,9 @@ void Graphics::copyBufferToTexture(Buffer *source, Texture *dest, size_t sourceo
 	}
 
 	Range sourcerange(sourceoffset, size);
+
+	if (sourceoffset % 4 != 0 || size % 4 != 0)
+		throw love::Exception("Buffer copy source offset and computed byte size must be multiples of 4 bytes.");
 
 	if (sourcerange.getMax() >= source->getSize())
 		throw love::Exception("Buffer copy source offset and width/height doesn't fit within the source Buffer.");

--- a/src/modules/graphics/metal/Buffer.h
+++ b/src/modules/graphics/metal/Buffer.h
@@ -41,6 +41,7 @@ public:
 	void *map(MapType map, size_t offset, size_t size) override;
 	void unmap(size_t usedoffset, size_t usedsize) override;
 	bool fill(size_t offset, size_t size, const void *data) override;
+	void clear(size_t offset, size_t size) override;
 	void copyTo(love::graphics::Buffer *dest, size_t sourceoffset, size_t destoffset, size_t size) override;
 
 	ptrdiff_t getHandle() const override { return (ptrdiff_t) buffer; }

--- a/src/modules/graphics/opengl/Buffer.h
+++ b/src/modules/graphics/opengl/Buffer.h
@@ -53,6 +53,7 @@ public:
 	void *map(MapType map, size_t offset, size_t size) override;
 	void unmap(size_t usedoffset, size_t usedsize) override;
 	bool fill(size_t offset, size_t size, const void *data) override;
+	void clear(size_t offset, size_t size) override;
 	void copyTo(love::graphics::Buffer *dest, size_t sourceoffset, size_t destoffset, size_t size) override;
 
 	ptrdiff_t getHandle() const override { return buffer; };

--- a/src/modules/graphics/vulkan/Buffer.cpp
+++ b/src/modules/graphics/vulkan/Buffer.cpp
@@ -254,6 +254,20 @@ void Buffer::unmap(size_t usedoffset, size_t usedsize)
 	}
 }
 
+void Buffer::clear(size_t offset, size_t size)
+{
+	if (isImmutable())
+		throw love::Exception("Cannot clear an immutable Buffer.");
+	else if (isMapped())
+		throw love::Exception("Cannot clear a mapped Buffer.");
+	else if (offset + size > getSize())
+		throw love::Exception("The given offset and size parameters to clear() are not within the Buffer's size.");
+	else if (offset % 4 != 0 || size % 4 != 0)
+		throw love::Exception("clear() must be used with offset and size parameters that are multiples of 4 bytes.");
+
+	vkCmdFillBuffer(vgfx->getCommandBufferForDataTransfer(), buffer, offset, size, 0);
+}
+
 void Buffer::copyTo(love::graphics::Buffer *dest, size_t sourceoffset, size_t destoffset, size_t size)
 {
 	auto commandBuffer = vgfx->getCommandBufferForDataTransfer();

--- a/src/modules/graphics/vulkan/Buffer.h
+++ b/src/modules/graphics/vulkan/Buffer.h
@@ -51,6 +51,7 @@ public:
 	void *map(MapType map, size_t offset, size_t size) override;
 	void unmap(size_t usedoffset, size_t usedsize) override;
 	bool fill(size_t offset, size_t size, const void *data) override;
+	void clear(size_t offset, size_t size) override;
 	void copyTo(love::graphics::Buffer *dest, size_t sourceoffset, size_t destoffset, size_t size) override;
 	ptrdiff_t getHandle() const override;
 	ptrdiff_t getTexelBufferHandle() const override;

--- a/src/modules/graphics/wrap_Buffer.cpp
+++ b/src/modules/graphics/wrap_Buffer.cpp
@@ -318,6 +318,24 @@ static int w_Buffer_setArrayData(lua_State *L)
 	return 0;
 }
 
+static int w_Buffer_clear(lua_State *L)
+{
+	Buffer *t = luax_checkbuffer(L, 1);
+	size_t offset = 0;
+	size_t size = t->getSize();
+	if (!lua_isnoneornil(L, 2))
+	{
+		lua_Number offsetp = luaL_checknumber(L, 2);
+		lua_Number sizep = luaL_checknumber(L, 3);
+		if (offsetp < 0 || sizep < 0)
+			return luaL_error(L, "Offset and size parameters cannot be negative.");
+		offset = (size_t) offsetp;
+		size = (size_t) sizep;
+	}
+	luax_catchexcept(L, [&]() { t->clear(offset, size); });
+	return 0;
+}
+
 static int w_Buffer_getElementCount(lua_State *L)
 {
 	Buffer *t = luax_checkbuffer(L, 1);
@@ -386,6 +404,7 @@ static int w_Buffer_isBufferType(lua_State *L)
 static const luaL_Reg w_Buffer_functions[] =
 {
 	{ "setArrayData", w_Buffer_setArrayData },
+	{ "clear", w_Buffer_clear },
 	{ "getElementCount", w_Buffer_getElementCount },
 	{ "getElementStride", w_Buffer_getElementStride },
 	{ "getSize", w_Buffer_getSize },


### PR DESCRIPTION
- Graphics
- - Added Buffer:clear, to reset all or part of a Buffer's contents to 0.
- - Improved error handling with love.graphics.copyBuffer.
- Data
- - Migrated float/int getter methods to Data.
- - Added ByteData:setString.
- - Added a variant of love.data.pack which takes in ByteData.
- - Fixed an error message with ByteData:set*.