### PR TITLE
Weekly Merge #12

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -11,7 +11,6 @@ Released: N/A
 * Added love.event.restart(optionalvalue). A new love.restart field will contain the value after restarting.
 * Added love.system.getPreferredLocales.
 * Added love.localechanged callback.
-* Added love.dropbegan and love.dropcompleted callbacks.
 * Added love.audiodisconnected callback.
 * Added love.filesystem.mountFullPath and love.filesystem.unmountFullPath, including opt-in mount-for-write support.
 * Added love.filesystem.mountCommonPath, unmountCommonPath, and getFullCommonPath.

--- a/src/modules/event/sdl/Event.cpp
+++ b/src/modules/event/sdl/Event.cpp
@@ -414,12 +414,6 @@ Message *Event::convert(const SDL_Event &e)
 		}
 		SDL_free(e.drop.file);
 		break;
-	case SDL_DROPBEGIN:
-		msg = new Message("dropbegan");
-		break;
-	case SDL_DROPCOMPLETE:
-		msg = new Message("dropcompleted");
-		break;
 	case SDL_QUIT:
 	case SDL_APP_TERMINATING:
 		msg = new Message("quit");

--- a/src/modules/love/callbacks.lua
+++ b/src/modules/love/callbacks.lua
@@ -115,12 +115,6 @@ function love.createhandlers()
 		directorydropped = function (dir)
 			if love.directorydropped then return love.directorydropped(dir) end
 		end,
-		dropbegan = function ()
-			if love.dropbegan then return love.dropbegan() end
-		end,
-		dropcompleted = function ()
-			if love.dropcompleted then return love.dropcompleted() end
-		end,
 		lowmemory = function ()
 			if love.lowmemory then love.lowmemory() end
 			collectgarbage()


### PR DESCRIPTION
Quick patch:
- Remove love.dropbegan and love.dropcompleted callbacks. They don't quite function properly and can be implemented outside of LOVE.