### PR TITLE
Weekly Merge 19

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -79,6 +79,7 @@ Released: N/A
 * Added love.sensor module.
 * Added love.sensorupdated callback.
 * Added love.joysticksensorupdated callback.
+* Added variant for enet peer:send and host:broadcast which accepts a pointer (light userdata) and a size.
 
 * Changed love.filesystem.exists to no longer be deprecated.
 * Changed the default font from Vera size 12 to Noto Sans size 13.

--- a/changes.txt
+++ b/changes.txt
@@ -138,9 +138,26 @@ Released: N/A
 	* Removed RevoluteJoint:hasLimitsEnabled (renamed to RevoluteJoint:areLimitsEnabled).
 
 * Fixed BezierCurve:render adding collinear points in some situations.
-* Fixed line rendering when the line has duplicate points.
 * Fixed sound Decoders to cause a Lua error instead of hard-crashing when memory for the decoding buffer can't be allocated.
-* Fixed oversaturated colors on macOS when a P3-capable display is used.
+
+LOVE 11.5 [Mysterious Mysteries]
+--------------------------------
+
+Released: N/A
+
+* Fixed love.threaderror not being called if the error message is an empty string.
+* Fixed a race condition when a Thread is destroyed immediately after Thread:start.
+* Fixed unexpectedly slow first frames on macOS.
+* Fixed time drift in Source:tell after a Source loops.
+* Fixed audio not always pausing when the app is minimized on Android.
+* Fixed the original window size not always being restored when exiting fullscreen on Linux.
+* Fixed some cases of framerate hitches in Windows when vsync is enabled in windowed mode.
+* Fixed colors appearing over-saturated on P3 displays in macOS.
+* Fixed textures looking washed out when gamma-correct rendering is used on some Android devices.
+* Fixed images with mipmaps when ANGLE is used with an AMD GPU.
+* Fixed line rendering when duplicate points are used in the line.
+* Fixed line rendering with miter and bevel line join modes when antiparallel lines are formed.
+* Fixed a crash when calling Text:add with an empty string parameter.
 
 LOVE 11.4 [Mysterious Mysteries]
 --------------------------------

--- a/changes.txt
+++ b/changes.txt
@@ -140,6 +140,7 @@ Released: N/A
 
 * Fixed BezierCurve:render adding collinear points in some situations.
 * Fixed sound Decoders to cause a Lua error instead of hard-crashing when memory for the decoding buffer can't be allocated.
+* Fixed enum misspelling for thousandsseparator from thsousandsseparator for both keyboard and scancode enums.
 
 LOVE 11.5 [Mysterious Mysteries]
 --------------------------------

--- a/src/libraries/enet/enet.cpp
+++ b/src/libraries/enet/enet.cpp
@@ -234,12 +234,21 @@ static void push_event(lua_State *l, ENetEvent *event) {
 
 /**
  * Read a packet off the stack as a string
- * idx is position of string
+ * idx is position of string or lightuserdata
  */
 static ENetPacket *read_packet(lua_State *l, int idx, enet_uint8 *channel_id) {
 	size_t size;
 	int argc = lua_gettop(l);
-	const void *data = luaL_checklstring(l, idx, &size);
+	const void* data;
+
+	if (lua_islightuserdata(l, idx)) {
+		data = lua_touserdata(l, idx);
+		size = (size_t) luaL_checknumber(l, idx + 1);
+		idx++;
+	}
+	else {
+		data = luaL_checklstring(l, idx, &size);
+	}
 	ENetPacket *packet;
 
 	enet_uint32 flags = ENET_PACKET_FLAG_RELIABLE;

--- a/src/modules/graphics/TextBatch.cpp
+++ b/src/modules/graphics/TextBatch.cpp
@@ -255,6 +255,10 @@ void TextBatch::draw(Graphics *gfx, const Matrix4 &m)
 
 	gfx->flushBatchedDraws();
 
+	// Re-generate the text if the Font's texture cache was invalidated.
+	if (font->getTextureCacheID() != textureCacheID)
+		regenerateVertices();
+
 	if (Shader::isDefaultActive())
 		Shader::attachDefault(Shader::STANDARD_DEFAULT);
 
@@ -264,10 +268,6 @@ void TextBatch::draw(Graphics *gfx, const Matrix4 &m)
 
 	if (Shader::current)
 		Shader::current->validateDrawState(PRIMITIVE_TRIANGLES, firsttex);
-
-	// Re-generate the text if the Font's texture cache was invalidated.
-	if (font->getTextureCacheID() != textureCacheID)
-		regenerateVertices();
 
 	int totalverts = 0;
 	for (const Font::DrawCommand &cmd : drawCommands)

--- a/src/modules/keyboard/Keyboard.cpp
+++ b/src/modules/keyboard/Keyboard.cpp
@@ -221,7 +221,7 @@ StringMap<Keyboard::Key, Keyboard::KEY_MAX_ENUM>::Entry Keyboard::keyEntries[] =
 	{"oper", Keyboard::KEY_OPER},
 	{"clearagain", Keyboard::KEY_CLEARAGAIN},
 
-	{"thsousandsseparator", Keyboard::KEY_THOUSANDSSEPARATOR},
+	{"thousandsseparator", Keyboard::KEY_THOUSANDSSEPARATOR},
 	{"decimalseparator", Keyboard::KEY_DECIMALSEPARATOR},
 	{"currencyunit", Keyboard::KEY_CURRENCYUNIT},
 	{"currencysubunit", Keyboard::KEY_CURRENCYSUBUNIT},
@@ -442,7 +442,7 @@ StringMap<Keyboard::Scancode, Keyboard::SCANCODE_MAX_ENUM>::Entry Keyboard::scan
 
 	{"kp00", SCANCODE_KP_00},
 	{"kp000", SCANCODE_KP_000},
-	{"thsousandsseparator", SCANCODE_THOUSANDSSEPARATOR},
+	{"thousandsseparator", SCANCODE_THOUSANDSSEPARATOR},
 	{"decimalseparator", SCANCODE_DECIMALSEPARATOR},
 	{"currencyunit", SCANCODE_CURRENCYUNIT},
 	{"currencysubunit", SCANCODE_CURRENCYSUBUNIT},

--- a/src/modules/love/boot.lua
+++ b/src/modules/love/boot.lua
@@ -367,7 +367,8 @@ function love.init()
 			minheight = c.window.minheight,
 			borderless = c.window.borderless,
 			centered = c.window.centered,
-			display = c.window.display,
+			displayindex = c.window.displayindex,
+			display = c.window.display, -- deprecated
 			highdpi = c.window.highdpi, -- deprecated
 			usedpiscale = c.window.usedpiscale,
 			x = c.window.x,


### PR DESCRIPTION
ENET:
- Added variants for peer_send and host_broadcast that take light userdata.
Font:
- Added RTL fallback font support
Keyboard:
- Fixed misspelling of "thousandsseparator" in both keyboard and scancode enums.
Window:
- Fixed t.window.displayindex in love.conf. (t.window.display is deprecated.)

As always, thanks to all the contributors that made this possible.
